### PR TITLE
fix(definitions): Correct error handling when testing JDBC connection

### DIFF
--- a/app/inspector/engines/interface.py
+++ b/app/inspector/engines/interface.py
@@ -14,6 +14,10 @@ class EngineInterface(object):
 
     indexes_sql = None
 
+    connect_timeout_attr = None
+
+    connect_timeout_value = 5
+
     def __init__(self, host, username, password, port, database):
         self.host = host
         self.username = username
@@ -32,13 +36,16 @@ class EngineInterface(object):
 
     @property
     def connect_kwargs(self):
-        return {
+        _kwargs = {
             'host': self.host,
             'user': self.username,
             'password': self.password,
             'port': self.port,
             'database': self.database,
         }
+        if self.connect_timeout_attr is not None:
+            _kwargs[self.connect_timeout_attr] = self.connect_timeout_value
+        return _kwargs
 
     @property
     def version(self):

--- a/app/inspector/engines/mysql_inspector.py
+++ b/app/inspector/engines/mysql_inspector.py
@@ -105,6 +105,8 @@ class MySQLInspector(interface.EngineInterface):
 
     indexes_sql = MYSQL_INDEXES_QUERY
 
+    connect_timeout_attr = 'connect_timeout'
+
     @classmethod
     def has_indexes(self):
         return True

--- a/app/inspector/engines/postgresql_inspector.py
+++ b/app/inspector/engines/postgresql_inspector.py
@@ -98,6 +98,8 @@ class PostgresInspector(interface.EngineInterface):
 
     indexes_sql = POSTGRESQL_INDEXES_QUERY
 
+    connect_timeout_attr = 'connect_timeout'
+
     @classmethod
     def has_indexes(self):
         return True

--- a/app/inspector/engines/redshift_inspector.py
+++ b/app/inspector/engines/redshift_inspector.py
@@ -63,6 +63,8 @@ class RedshiftInspector(interface.EngineInterface):
 
     definitions_sql = REDSHIFT_DEFINITIONS_SQL
 
+    connect_timeout_attr = 'connect_timeout'
+
     @classmethod
     def has_indexes(self):
         return False

--- a/app/inspector/engines/snowflake_inspector.py
+++ b/app/inspector/engines/snowflake_inspector.py
@@ -56,6 +56,8 @@ class SnowflakeInspector(interface.EngineInterface):
 
     definitions_sql = SNOWFLAKE_DEFINITIONS_QUERY
 
+    connect_timeout_attr = 'login_timeout'
+
     @classmethod
     def has_indexes(self):
         return False
@@ -64,9 +66,10 @@ class SnowflakeInspector(interface.EngineInterface):
     def connect_kwargs(self):
         return {
             'account': self.host,
-            'user': self.username,
-            'password': self.password,
             'database': self.database,
+            'password': self.password,
+            'user': self.username,
+            'login_timeout': self.connect_timeout_value,
         }
 
     @property

--- a/app/inspector/engines/sqlserver_inspector.py
+++ b/app/inspector/engines/sqlserver_inspector.py
@@ -105,6 +105,8 @@ class SQLServerInspector(interface.EngineInterface):
 
     indexes_sql = SQLSERVER_INDEXES_QUERY
 
+    connect_timeout_attr = 'login_timeout'
+
     @classmethod
     def has_indexes(self):
         return True

--- a/app/inspector/tests/engines/test_mysql_inspector.py
+++ b/app/inspector/tests/engines/test_mysql_inspector.py
@@ -91,3 +91,15 @@ class MySQLInspectorTests(unittest.TestCase):
         """It should implement MySQL.version
         """
         self.assertEqual(self.engine.version, '10.1.2')
+
+    def test_connect_kwargs(self):
+        """It should have the connect timeout parameter.
+        """
+        assert self.engine.connect_kwargs == {
+            'host': 'localhost',
+            'user': 'admin',
+            'password': '1234567890',
+            'port': 3306,
+            'database': 'acme',
+            'connect_timeout': 5,
+        }

--- a/app/inspector/tests/engines/test_snowflake_inspector.py
+++ b/app/inspector/tests/engines/test_snowflake_inspector.py
@@ -60,6 +60,7 @@ class SnowflakeInspectorTests(unittest.TestCase):
             'user': 'admin',
             'password': '1234567890',
             'database': 'acme',
+            'login_timeout': 5,
         }
 
     def test_sys_schemas(self):

--- a/www/cypress/integration/datastores.spec.js
+++ b/www/cypress/integration/datastores.spec.js
@@ -88,7 +88,7 @@ describe("datastores.spec.js", () => {
       )
     })
 
-    it("fails when cannot connect", () => {
+    it("fails when Postgres cannot connect", () => {
       cy.login(member.email, member.password, workspace.id)
         .then(() =>
           cy.visit(inventoryUri))
@@ -118,6 +118,73 @@ describe("datastores.spec.js", () => {
       )
 
       // Test Connection button should still be visible.
+      cy.getByTestId("DatastoreSetupForm.TestConnection")
+        .should("be.visible")
+        .should("contain", "Test Connection")
+    })
+
+    it("fails when MySQL cannot connect", () => {
+      cy.login(member.email, member.password, workspace.id)
+        .then(() =>
+          cy.visit(inventoryUri))
+
+      cy.contains("Connect a Datastore").click()
+      cy.contains("MySQL").click()
+
+      cy.getByTestId("DatastoreSetupForm.ValidateEngine").click()
+
+      cy.fillInputs({
+        "ConnectionSettingsFieldset.Host": "mysqldb",
+        "ConnectionSettingsFieldset.Port": "3306",
+        "ConnectionSettingsFieldset.Username": "employees",
+        "ConnectionSettingsFieldset.Password": "notreal",
+        "ConnectionSettingsFieldset.Database": "employees",
+      })
+
+      cy.getByTestId("DatastoreSetupForm.TestConnection")
+        .should("be.visible")
+        .should("contain", "Test Connection")
+        .click()
+
+      cy.contains(
+        ".ant-message-error", "2003: Can't connect to MySQL server on 'mysqldb:3306' (-2 Name or service not known)"
+      ).should(
+        "be.visible"
+      )
+
+      cy.getByTestId("DatastoreSetupForm.TestConnection")
+        .should("be.visible")
+        .should("contain", "Test Connection")
+    })
+
+    it("fails when Snowflake cannot connect", () => {
+      cy.login(member.email, member.password, workspace.id)
+        .then(() =>
+          cy.visit(inventoryUri))
+
+      cy.contains("Connect a Datastore").click()
+      cy.contains("Snowflake").click()
+
+      cy.getByTestId("DatastoreSetupForm.ValidateEngine").click()
+
+      cy.fillInputs({
+        "ConnectionSettingsFieldset.Host": "mm-testing",
+        "ConnectionSettingsFieldset.Username": "cypress",
+        "ConnectionSettingsFieldset.Password": "automated-cypress-test",
+        "ConnectionSettingsFieldset.Database": "test_db",
+      })
+
+      cy.getByTestId("DatastoreSetupForm.TestConnection")
+        .should("be.visible")
+        .should("contain", "Test Connection")
+        .click()
+
+      cy.contains(
+        ".ant-message-error", "250001 (08001): Failed to connect to DB. Verify the account name is correct: mm-testing.snowflakecomputing.com:443. HTTP 403: Forbidden"
+      ).should(
+        "be.visible"
+      )
+
       cy.getByTestId("DatastoreSetupForm.TestConnection")
         .should("be.visible")
         .should("contain", "Test Connection")

--- a/www/src/app/Datastores/DatastoreSetupForm.js
+++ b/www/src/app/Datastores/DatastoreSetupForm.js
@@ -91,7 +91,7 @@ class DatastoreSetupForm extends Component {
           setTimeout(() => that.handleTestConnection(variables, response), 1000)
         })
         .catch((err) => {
-          that.setState({ connectionIsTesting: false })
+          setTimeout(() => that.handleTestConnectionFailure(err.graphQLErrors), 1000)
         })
     }
   }
@@ -111,6 +111,14 @@ class DatastoreSetupForm extends Component {
       connectionProperties,
       connectionIsTesting: false,
     })
+  }
+
+  handleTestConnectionFailure = (errors) => {
+    if (errors && errors.length > 0) {
+      message.error(errors[0].message)
+    }
+
+    this.setState({ connectionIsTesting: false })
   }
 
   renderButton = (currentStep) => {
@@ -224,7 +232,7 @@ class DatastoreSetupForm extends Component {
                   )(
                     <Radio.Group size="large" className="radio-icon">
                       {map(datastoreEngines || [], ({ label, dialect }) => (
-                        <Radio.Button value={dialect}>
+                        <Radio.Button value={dialect} key={dialect}>
                           <Avatar
                             shape="square"
                             src={`/assets/static/img/datastores/dialects/${dialect}.png`}

--- a/www/src/lib/links.js
+++ b/www/src/lib/links.js
@@ -46,7 +46,18 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   if (networkError) console.log(`[Network error]: ${networkError}`);
 })
 
-const retryLink = new RetryLink();
+const doNotRetry = ['testJdbcConnection']
+
+const retryLink = new RetryLink({
+  attempts: (count, operation, error) => {
+    return !!error && doNotRetry.indexOf(operation.operationName) > -1;
+  },
+  delay: {
+    initial: 300,
+    max: Infinity,
+    jitter: true
+  },
+});
 
 const link = ApolloLink.from([
   retryLink,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Bug Fix

## Description

Addresses a small bug where certain connection errors don't get displayed as flash notifications. This is caused by (1) network errors (for which [we added timeouts](https://github.com/getmetamapper/metamapper/blob/7bd0666d0de5fed7f0529b5f9a806aac834abedb/app/inspector/engines/interface.py#L46)) or (2) just not [catching GraphQL errors properly](https://github.com/getmetamapper/metamapper/blob/7bd0666d0de5fed7f0529b5f9a806aac834abedb/www/src/app/Datastores/DatastoreSetupForm.js#L94).

## Related Issues and Documents

https://trello.com/c/9bEp887f