### PR TITLE
feat(groups): Add profile pages for Groups

### DIFF
--- a/app/authorization/schema.py
+++ b/app/authorization/schema.py
@@ -54,6 +54,8 @@ class MembershipType(AuthNode, DjangoObjectType):
 class GroupType(AuthNode, DjangoObjectType):
     permission_classes = (WorkspaceTeamMembersOnly,)
 
+    pk = graphene.Int()
+
     users_count = graphene.Int()
 
     class Meta:
@@ -63,7 +65,10 @@ class GroupType(AuthNode, DjangoObjectType):
         interfaces = (relay.Node,)
         connection_class = connections.DefaultConnection
 
+    def resolve_pk(instance, info):
+        return instance.id
+
     def resolve_users_count(instance, info):
-        """Get the number of users that belong to this group.
+        """TODO(scruwys): Move this to a loader.
         """
         return instance.user_set.count()

--- a/www/cypress/integration/groups.spec.js
+++ b/www/cypress/integration/groups.spec.js
@@ -125,7 +125,7 @@ describe("groups.spec.js", () => {
           "be.visible"
         )
 
-        cy.getByTestId("GroupsTable").contains(formInputs.name).parent("tr").within(() => {
+        cy.getByTestId("GroupsTable").contains("tr", formInputs.name).within(() => {
           cy.get("td").eq(0).contains(formInputs.name)
           cy.get("td").eq(1).contains("0")
           cy.get("td").eq(2).contains(formInputs.desc)
@@ -156,7 +156,7 @@ describe("groups.spec.js", () => {
       })
 
       it("using UI", () => {
-        cy.getByTestId("GroupsTable").contains("Everybody").parent("tr").within(() => {
+        cy.getByTestId("GroupsTable").contains("tr", "Everybody").within(() => {
           cy.contains("Edit").click()
         })
 
@@ -176,7 +176,7 @@ describe("groups.spec.js", () => {
           "be.visible"
         )
 
-        cy.getByTestId("GroupsTable").contains(formInputs.name).parent("tr").within(() => {
+        cy.getByTestId("GroupsTable").contains("tr", formInputs.name).within(() => {
           cy.get("td").eq(0).contains(formInputs.name)
           cy.get("td").eq(1).contains("7")
           cy.get("td").eq(2).contains(formInputs.desc)
@@ -207,7 +207,7 @@ describe("groups.spec.js", () => {
       })
 
       it("using UI", () => {
-        cy.getByTestId("GroupsTable").contains("Executives").parent("tr").within(() => {
+        cy.getByTestId("GroupsTable").contains("tr", "Executives").within(() => {
           cy.contains("Delete").click()
         })
 
@@ -242,7 +242,7 @@ describe("groups.spec.js", () => {
     })
 
     it("displays a paginated list of users", () => {
-      cy.getByTestId("GroupsTable").contains("Everyone").parent("tr").within(() => {
+      cy.getByTestId("GroupsTable").contains("tr", "Everyone").within(() => {
         cy.get("td").eq(1).click()
       })
 
@@ -256,7 +256,7 @@ describe("groups.spec.js", () => {
     })
 
     it("filters users via search", () => {
-      cy.getByTestId("GroupsTable").contains("Everyone").parent("tr").within(() => {
+      cy.getByTestId("GroupsTable").contains("tr", "Everyone").within(() => {
         cy.get("td").eq(1).click()
       })
 
@@ -293,7 +293,7 @@ describe("groups.spec.js", () => {
     it("using UI", () => {
       const targetUser = "Bugs Bunny"
 
-      cy.getByTestId("GroupsTable").contains("Everyone").parent("tr").within(() => {
+      cy.getByTestId("GroupsTable").contains("tr", "Everyone").within(() => {
         cy.get("td").eq(1).click()
       })
 
@@ -319,7 +319,7 @@ describe("groups.spec.js", () => {
     it("using UI", () => {
       const targetUser = "Bugs Bunny"
 
-      cy.getByTestId("GroupsTable").contains("Everyone").parent("tr").within(() => {
+      cy.getByTestId("GroupsTable").contains("tr", "Everyone").within(() => {
         cy.get("td").eq(1).click()
       })
 
@@ -338,6 +338,28 @@ describe("groups.spec.js", () => {
     })
   })
 
+  describe("view group profile", () => {
+    const group = {
+      id: "R3JvdXBUeXBlOjM3NDY0NjQw",
+      name: "Everyone",
+      description: "Everyone in the organization is in this group."
+    }
+
+    beforeEach(() => {
+      cy.login(member.email, member.password, workspace.id)
+        .then(() => cy.visit(`/${workspace.slug}/settings/groups/R3JvdXBUeXBlOjM3NDY0NjQw`))
+    })
+
+    it("using UI", () => {
+      cy.getByTestId("GroupProfile")
+        .should("be.visible")
+        .should("contain", group.name)
+        .should("contain", group.description)
+
+      cy.getByTestId("GroupUsersTable").get(".user-display-name").should("have.length", 5)
+    })
+  })
+
   describe("404", () => {
     it("when workspace does not exist", () => {
       cy.login(owner.email, owner.password)
@@ -351,6 +373,13 @@ describe("groups.spec.js", () => {
       cy.login(outsider.email, outsider.password)
         .then(() =>
           cy.visit(`/${workspace.slug}/settings/groups`))
+
+      cy.contains("Sorry, the page you are looking for doesn't exist.").should("be.visible")
+    })
+
+    it("when group does not exist", () => {
+      cy.login(owner.email, owner.password)
+        .then(() => cy.visit(`/${workspace.slug}/settings/groups/does-not-exist`))
 
       cy.contains("Sorry, the page you are looking for doesn't exist.").should("be.visible")
     })

--- a/www/cypress/plugins/index.js
+++ b/www/cypress/plugins/index.js
@@ -37,7 +37,7 @@ module.exports = (on, config) => {
 
   require('cypress-log-to-output').install(on, (type, event) => {
     if (event.level === 'error' || event.type === 'error') {
-      return true
+      return event.url.indexOf('https://www.gravatar.com/avatar') < 0
     }
 
     if (event.level === 'log' || event.type === 'log') {

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -3138,6 +3138,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
+    "blueimp-md5": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.17.0.tgz",
+      "integrity": "sha512-x5PKJHY5rHQYaADj6NwPUR2QRCUVSggPzrUKkeENpj871o9l9IefJbO2jkT5UvYykeOK9dx0VmkIo6dZ+vThYw=="
+    },
     "bn.js": {
       "version": "4.11.9",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",

--- a/www/package.json
+++ b/www/package.json
@@ -11,6 +11,7 @@
     "apollo-link-error": "^1.1.12",
     "apollo-link-retry": "^2.2.16",
     "apollo-upload-client": "^11.0.0",
+    "blueimp-md5": "^2.17.0",
     "craco-antd": "^1.18.1",
     "elliptic": "^6.5.3",
     "graphql": "^14.5.8",

--- a/www/src/app/Common/GroupAvatar/index.js
+++ b/www/src/app/Common/GroupAvatar/index.js
@@ -1,7 +1,5 @@
 import React from "react"
-import md5 from "blueimp-md5"
 import { Avatar } from "antd"
-import { coalesce } from "lib/utilities"
 
 const avatarColors = [
   { color: "#f56a00", backgroundColor: "#fde3cf" }, // orange
@@ -13,21 +11,17 @@ const avatarColors = [
   { color: "#6a00f5", backgroundColor: "#e3cffd" }, // purple
 ]
 
-const UserAvatar = ({ pk, name, email, noColor }) => (
+const GroupAvatar = ({ pk, name, noColor, size }) => (
   <div className="avatar">
-    <Avatar
-      src={`https://www.gravatar.com/avatar/${md5(email.toLowerCase())}?d=404`}
-      style={noColor ? { backgroundColor: "#cccccc" } : avatarColors[pk % avatarColors.length]}
-    >
-      {coalesce(name, email)[0].toUpperCase()}
+    <Avatar style={noColor ? {} : avatarColors[pk % avatarColors.length]} size={size}>
+      {name[0].toUpperCase()}
     </Avatar>
   </div>
 )
 
-UserAvatar.defaultProps = {
-  email: null,
-  name: null,
+GroupAvatar.defaultProps = {
   noColor: false,
+  size: 32,
 }
 
-export default UserAvatar
+export default GroupAvatar

--- a/www/src/app/Groups/GroupProfileInner.js
+++ b/www/src/app/Groups/GroupProfileInner.js
@@ -1,0 +1,41 @@
+import React, { Fragment } from "react"
+import moment from "moment"
+import { Icon, Tooltip } from "antd"
+import GroupAvatar from "app/Common/GroupAvatar"
+import Link from "app/Navigation/Link"
+
+const GroupProfileInner = ({
+  avatarSize,
+  group,
+  showDescription,
+  showLink,
+}) => (
+   <Fragment>
+      <div className="group-profile-avatar">
+        <GroupAvatar size={avatarSize} {...group} />
+      </div>
+      <div className="group-profile-metadata">
+        <span className="group-profile-name">
+          {showLink ? <Link to={`/settings/groups/${group.id}`}>{group.name}</Link> : group.name}
+        </span>
+        <ul>
+          <li>
+            <Tooltip title="Created On" placement="bottom">
+              <Icon type="clock-circle" /> {moment(group.createdAt).format('MMM DD, YYYY')}
+            </Tooltip>
+          </li>
+        </ul>
+        {showDescription && (
+          <div className="group-profile-description">{group.description}</div>
+        )}
+      </div>
+   </Fragment>
+)
+
+GroupProfileInner.defaultProps = {
+    avatarSize: 32,
+    showDescription: false,
+    showLink: false,
+}
+
+export default GroupProfileInner

--- a/www/src/app/Groups/GroupProfilePopover.js
+++ b/www/src/app/Groups/GroupProfilePopover.js
@@ -1,0 +1,25 @@
+import React from "react"
+import { compose } from "react-apollo"
+import { Popover } from "antd"
+import withGetWorkspaceGroupById from "graphql/withGetWorkspaceGroupById"
+import { withPopoverLoader } from "hoc/withLoader"
+import GroupProfileInner from "app/Groups/GroupProfileInner"
+
+const GroupProfilePopoverContent = ({ workspaceGroup }) => (
+  <div className="group-profile-popover">
+    <GroupProfileInner group={workspaceGroup} showLink />
+  </div>
+)
+
+const WrappedGroupProfilePopoverContent = compose(
+    withGetWorkspaceGroupById,
+    withPopoverLoader,
+)(GroupProfilePopoverContent)
+
+const GroupProfilePopover = ({ children, groupId }) => (
+  <Popover content={<WrappedGroupProfilePopoverContent groupId={groupId} />} placement="right">
+    {children}
+  </Popover>
+)
+
+export default GroupProfilePopover

--- a/www/src/app/WorkspaceSettings/Groups/GroupsTable.js
+++ b/www/src/app/WorkspaceSettings/Groups/GroupsTable.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from "react"
 import { Table } from "antd"
 import { withLargeLoader } from "hoc/withLoader"
 import AvatarStacked from "app/Common/AvatarStacked"
+import Link from "app/Navigation/Link"
 import withGetWorkspaceGroups from "graphql/withGetWorkspaceGroups"
 
 class GroupsTable extends Component {
@@ -11,8 +12,7 @@ class GroupsTable extends Component {
     this.columns = [
       {
         title: "Name",
-        dataIndex: "name",
-        key: "name",
+        render: ({ id, name }) => <Link to={`/settings/groups/${id}`}>{name}</Link>
       },
       {
         title: "Users",

--- a/www/src/app/WorkspaceSettings/Groups/ManageGroupUsers.js
+++ b/www/src/app/WorkspaceSettings/Groups/ManageGroupUsers.js
@@ -45,11 +45,11 @@ class ManageGroupUsers extends Component {
     const {
       form,
       group,
-      workspaceUsers,
       hasPermission,
+      onCancel,
       submitting,
       visible,
-      onCancel,
+      workspaceUsers,
     } = this.props
     return (
       <Modal
@@ -70,6 +70,7 @@ class ManageGroupUsers extends Component {
         )}
         <ManageGroupUsersTable
           group={group}
+          workspaceUsers={workspaceUsers}
           hasPermission={hasPermission}
           onRemove={this.handleRemoveUser}
         />

--- a/www/src/app/WorkspaceSettings/Groups/ManageGroupUsersTable.js
+++ b/www/src/app/WorkspaceSettings/Groups/ManageGroupUsersTable.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react"
 import { Button, Icon, Input, Table } from "antd"
+import { compose } from "react-apollo"
 import { coalesce } from "lib/utilities"
 import DisplayUsername from "app/WorkspaceSettings/Users/DisplayUsername"
 import withGetWorkspaceGroupUsers from "graphql/withGetWorkspaceGroupUsers"
@@ -116,11 +117,12 @@ class ManageGroupUsersTable extends Component {
           rowKey="id"
           dataSource={workspaceGroupUsers}
           columns={columns}
-          pagination={{ pageSize: 5 }}
+          pagination={{ simple: true, pageSize: 5 }}
+          locale={{ emptyText: "This group has no active members." }}
         />
       </span>
     )
   }
 }
 
-export default withGetWorkspaceGroupUsers(withLargeLoader(ManageGroupUsersTable))
+export default compose(withGetWorkspaceGroupUsers, withLargeLoader)(ManageGroupUsersTable)

--- a/www/src/graphql/queries/GetWorkspaceGroup.js
+++ b/www/src/graphql/queries/GetWorkspaceGroup.js
@@ -1,20 +1,14 @@
 import gql from "graphql-tag"
 
 export default gql`
-  query workspaceGroup($id: ID!) {
-    workspaceGroup(id: $id) {
+  query workspaceGroup($groupId: ID!) {
+    workspaceGroup(id: $groupId) {
+      id
+      pk
       name
       description
       createdAt
-      users {
-        edges {
-          node {
-            name
-            userId
-            email
-          }
-        }
-      }
+      usersCount
     }
   }
 `

--- a/www/src/graphql/withGetWorkspaceGroupById.js
+++ b/www/src/graphql/withGetWorkspaceGroupById.js
@@ -1,12 +1,8 @@
 import { graphql } from "react-apollo"
 import GetWorkspaceGroup from "graphql/queries/GetWorkspaceGroup"
 
-const withGetWorkspaceGroup = graphql(GetWorkspaceGroup, {
-  options: ({
-    match: {
-      params: { groupId },
-    },
-  }) => ({
+const withGetWorkspaceGroupById = graphql(GetWorkspaceGroup, {
+  options: ({ groupId }) => ({
     fetchPolicy: "network-only",
     variables: { groupId },
   }),
@@ -28,4 +24,4 @@ const withGetWorkspaceGroup = graphql(GetWorkspaceGroup, {
   },
 })
 
-export default withGetWorkspaceGroup
+export default withGetWorkspaceGroupById

--- a/www/src/hoc/withLoader.js
+++ b/www/src/hoc/withLoader.js
@@ -19,6 +19,14 @@ const withLoader = (opts = {}) => (ChildComponent) => {
   return withInnerLoader
 }
 
+export const withPopoverLoader = withLoader({
+  size: "small",
+  wrapperstyles: {
+    textAlign: "center",
+    margin: "16px 40px"
+  },
+})
+
 export const withLargeLoader = withLoader({
   size: "large",
   wrapperstyles: {

--- a/www/src/index.scss
+++ b/www/src/index.scss
@@ -7,6 +7,7 @@ $color-links: #f7777b;
 $color-links-hover: #11A4CD;
 $color-border: #e8e8e8;
 $color-light-grey: #e8e8e8;
+$color-dark: rgba(0, 0, 0, 0.65);
 
 @import './pages/_overrides.scss';
 @import './pages/_navigation.scss';

--- a/www/src/pages/WorkspaceSettings/GroupProfile.js
+++ b/www/src/pages/WorkspaceSettings/GroupProfile.js
@@ -1,0 +1,59 @@
+import React from "react"
+import { compose } from "react-apollo"
+import { Card, Col, Row } from "antd"
+import withGetWorkspaceGroup from "graphql/withGetWorkspaceGroup"
+import withNotFoundHandler from 'hoc/withNotFoundHandler'
+import { withLargeLoader } from "hoc/withLoader"
+import ManageGroupUsersTable from "app/WorkspaceSettings/Groups/ManageGroupUsersTable"
+import Breadcrumbs from "app/Navigation/Breadcrumbs"
+import GroupProfileInner from "app/Groups/GroupProfileInner"
+
+const breadcrumbs = (workspaceSlug, group) => {
+  return [
+    {
+      label: "Home",
+      to: `/${workspaceSlug}/datastores`,
+    },
+    {
+      label: "Workspace Settings",
+      to: `/${workspaceSlug}/settings`,
+    },
+    {
+      label: "Groups",
+      to: `/${workspaceSlug}/settings/groups`,
+    },
+    {
+      label: group.name,
+    },
+  ]
+}
+
+const GroupProfile = ({ currentWorkspace, workspaceGroup }) => (
+  <Row className="group-profile">
+    <Col span={8} offset={8}>
+      <div className="breadcrumbs-wrapper">
+        <Breadcrumbs breadcrumbs={breadcrumbs(currentWorkspace.slug, workspaceGroup)} />
+      </div>
+      <Card data-test="GroupProfile">
+        <div className="group-profile-header">
+          <GroupProfileInner group={workspaceGroup} avatarSize={64} showDescription />
+        </div>
+        <ManageGroupUsersTable
+          group={workspaceGroup}
+          hasPermission={false}
+          onRemove={null}
+        />
+      </Card>
+    </Col>
+  </Row>
+)
+
+const withNotFound = withNotFoundHandler(({ workspaceGroup }) => {
+  return !workspaceGroup || !workspaceGroup.hasOwnProperty("id")
+})
+
+export default compose(
+  withGetWorkspaceGroup,
+  withLargeLoader,
+  withNotFound,
+)(GroupProfile)

--- a/www/src/pages/WorkspaceSettings/Groups.js
+++ b/www/src/pages/WorkspaceSettings/Groups.js
@@ -79,15 +79,19 @@ class Groups extends Component {
 
   render() {
     const {
-      updatingGroup,
-      updateVisible,
-      deletingGroup,
       deleteVisible,
-      managingGroup,
+      deletingGroup,
       manageVisible,
+      managingGroup,
       setupVisible,
+      updateVisible,
+      updatingGroup,
     } = this.state
-    const { loading, hasPermission, workspace } = this.props
+    const {
+      loading,
+      hasPermission,
+      workspace,
+    } = this.props
     return (
       <WorkspaceLayout
         title={`Groups - ${workspace.slug} - Metamapper`}

--- a/www/src/pages/WorkspaceSettings/_workspacesettings.scss
+++ b/www/src/pages/WorkspaceSettings/_workspacesettings.scss
@@ -69,6 +69,93 @@
     text-align: left;
   }
 }
+.group-profile-metadata {
+  margin-top: 6px;
+  .group-profile-name {
+    font-weight: 700;
+  }
+  ul {
+    list-style-type: none;
+    padding: 0;
+    margin-bottom: 0;
+    margin-top: 6px;
+  }
+  ul > li {
+    color: #ccc;
+    font-weight: 400;
+    font-size: 14px;
+    padding-right: 12px;
+  }
+  ul > li .anticon {
+    margin-right: 4px;
+  }
+}
+.group-profile {
+  .breadcrumbs-wrapper {
+    border: 0;
+  }
+  .ant-card-body {
+    padding: 0;
+  }
+  .group-profile-header {
+    border-bottom: 1px solid #e8e8e8;
+    padding: 24px;
+    .group-profile-avatar {
+      display: inline-block;
+      float: left;
+      margin-right: 18px;
+    }
+    .group-profile-metadata {
+      ul > li {
+        display: inline-block;
+      }
+    }
+  }
+  .group-profile-description {
+    color: rgba(0, 0, 0, .45);
+    margin-top: 6px;
+  }
+  .groups-table {
+    .ant-table {
+      border: none;
+      margin-top: 0;
+    }
+    .ant-table-content {
+      border: none;
+    }
+    .ant-table-placeholder {
+      border-bottom: none;
+    }
+  }
+}
+.group-profile-popover {
+  display: inline-block;
+
+  a {
+    color: $color-dark;
+  }
+  a:hover {
+    color: $color-primary;
+  }
+  .group-profile-avatar {
+    float: left;
+    display: inline-block;
+    line-height: 40px;
+  }
+  .group-profile-metadata {
+    display: inline-block;
+    margin-left: 12px;
+
+    ul > li {
+      display: block;
+      margin-bottom: 6px;
+     }
+    ul > li:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
 
 .add-user-to-group-form {
   .ant-select-selection--single {

--- a/www/src/pages/_overrides.scss
+++ b/www/src/pages/_overrides.scss
@@ -122,6 +122,9 @@ trix-toolbar .trix-button-group {
 .ant-layout {
   background: $color-layout;
 }
+.ant-result-info .ant-result-icon > .anticon {
+  color: $color-primary;
+}
 .ant-select .ant-select-selection--single {
   height: 42px;
 }

--- a/www/src/routes/workspaces.js
+++ b/www/src/routes/workspaces.js
@@ -8,6 +8,7 @@ import AuthenticationSetupOAuth2Google from "pages/WorkspaceSettings/Authenticat
 import AuthenticationSetupSaml from "pages/WorkspaceSettings/AuthenticationSetupSaml"
 import AuthenticationSetupRouting from "pages/WorkspaceSettings/AuthenticationSetupRouting"
 import Groups from "pages/WorkspaceSettings/Groups"
+import GroupProfile from "pages/WorkspaceSettings/GroupProfile"
 import CustomFields from "pages/WorkspaceSettings/CustomFields"
 
 export default [
@@ -55,6 +56,12 @@ export default [
     component: Groups,
     path: "/:workspaceSlug/settings/groups",
     namespace: "workspace",
+    exact: true,
+  },
+  {
+    component: GroupProfile,
+    path: "/:workspaceSlug/settings/groups/:groupId",
+    namespace: "groups",
   },
   {
     component: General,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [X] Feature
- [ ] Bug Fix
- [ ] Other

## Description

This PR adds profile pages to Group objects. This allows a user to view what team members are in a group as well as the description of the group.

The eventual plan is to add groups as a custom field type. The group profile feature will more useful once that gets added as part of `v0.1.2`.
