### PR TITLE
feat(customfields): Add group as custom field type

### DIFF
--- a/app/customfields/scalars.py
+++ b/app/customfields/scalars.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 from graphene.types import Scalar
+from graphql_relay import to_global_id
+
 from app.authentication.models import User
+from app.authorization.models import Group
 
 
 class CustomPropScalar(Scalar):
@@ -14,6 +17,8 @@ class CustomPropScalar(Scalar):
             value = attrs['value']
             if isinstance(value, (User,)):
                 value = CustomPropScalar.serialize_user(value)
+            elif isinstance(value, (Group,)):
+                value = CustomPropScalar.serialize_group(value)
             output.append({
                 'fieldId': k,
                 'fieldLabel': label,
@@ -26,8 +31,20 @@ class CustomPropScalar(Scalar):
         """Builds the response for a User.
         """
         return {
+            'id': to_global_id('UserType', user.pk),
             'pk': user.pk,
             'name': user.name,
             'email': user.email,
             'type': 'User',
+        }
+
+    @staticmethod
+    def serialize_group(group):
+        """Builds the response for a Group.
+        """
+        return {
+            'id': to_global_id('GroupType', group.pk),
+            'pk': group.pk,
+            'name': group.name,
+            'type': 'Group',
         }

--- a/app/customfields/serializers.py
+++ b/app/customfields/serializers.py
@@ -73,6 +73,11 @@ class CustomFieldSerializer(MetamapperSerializer, serializers.ModelSerializer):
         validator.is_valid(raise_exception=True)
         return validator.data
 
+    def validate_group(self, data):
+        """Validators for GROUP type.
+        """
+        return {}
+
     def validate(self, data):
         """Handle custom validation based on the field_type value.
         """
@@ -81,6 +86,7 @@ class CustomFieldSerializer(MetamapperSerializer, serializers.ModelSerializer):
             models.CustomField.USER: self.validate_user,
             models.CustomField.TEXT: self.validate_text,
             models.CustomField.ENUM: self.validate_enum,
+            models.CustomField.GROUP: self.validate_group,
         }
         data['validators'] = validators[field_type](data.get('validators', {}))
         return data
@@ -127,6 +133,13 @@ class CustomPropertiesSerializer(MetamapperSerializer, serializers.Serializer):
             return 'The provided value is invalid.'
         return None
 
+    def validate_group(self, value, customfield):
+        """Validators for GROUP type.
+        """
+        if value and not self.instance.get_related_group(value):
+            return 'The provided group does not exist.'
+        return None
+
     def validate_properties(self, properties):
         """Perform property-level validation.
         """
@@ -134,6 +147,7 @@ class CustomPropertiesSerializer(MetamapperSerializer, serializers.Serializer):
             models.CustomField.USER: self.validate_user,
             models.CustomField.TEXT: self.validate_text,
             models.CustomField.ENUM: self.validate_enum,
+            models.CustomField.GROUP: self.validate_group,
         }
 
         custom_fields = {

--- a/app/customfields/tests/test_models.py
+++ b/app/customfields/tests/test_models.py
@@ -129,6 +129,7 @@ class CustomPropertiesTestsMixin(object):
         })
 
         workspace.revoke_membership(user)
+        resource.refresh_from_db()
 
         self.assertEqual(resource.get_custom_properties()[customfield.pk], {
             'label': 'Steward', 'value': None

--- a/app/customfields/tests/test_mutations.py
+++ b/app/customfields/tests/test_mutations.py
@@ -428,6 +428,7 @@ class UpdateCustomPropertiesTests(cases.GraphQLTestCase):
         }
 
         current_user = {
+            'id': helpers.to_global_id('UserType', self.user.pk),
             'pk': self.user.pk,
             'name': self.user.name,
             'email': self.user.email,

--- a/app/customfields/tests/test_queries.py
+++ b/app/customfields/tests/test_queries.py
@@ -86,6 +86,8 @@ class TestGetCustomProperties(cases.GraphQLTestCase):
         cls.datastore = factories.DatastoreFactory(workspace=cls.workspace)
         cls.global_id = helpers.to_global_id('DatastoreType', cls.datastore.pk)
 
+        cls.group = factories.GroupFactory(workspace_id=cls.workspace.id)
+
         cls.attributes = {
             'content_type': cls.datastore.content_type,
             'workspace': cls.workspace,
@@ -105,9 +107,14 @@ class TestGetCustomProperties(cases.GraphQLTestCase):
                 **cls.attributes,
             ),
             factories.CustomFieldFactory(
-                field_name='Team',
+                field_name='Department',
                 field_type=models.CustomField.ENUM,
                 validators={'choices': ['Data Engineering', 'Product', 'Design']},
+                **cls.attributes,
+            ),
+            factories.CustomFieldFactory(
+                field_name='Team',
+                field_type=models.CustomField.GROUP,
                 **cls.attributes,
             ),
         ]
@@ -115,6 +122,7 @@ class TestGetCustomProperties(cases.GraphQLTestCase):
         cls.datastore.custom_properties = {
             cls.customfields[0].pk: cls.user.pk,
             cls.customfields[2].pk: 'Design',
+            cls.customfields[3].pk: cls.group.pk,
         }
         cls.datastore.save()
 
@@ -128,8 +136,9 @@ class TestGetCustomProperties(cases.GraphQLTestCase):
                 'fieldId': self.customfields[0].pk,
                 'fieldLabel': self.customfields[0].field_name,
                 'fieldValue': {
-                    'name': 'Sam Crust',
                     'email': 'owner@metamapper.io',
+                    'id': 'VXNlclR5cGU6MQ==',
+                    'name': 'Sam Crust',
                     'pk': 1,
                     'type': 'User',
                 },
@@ -143,7 +152,16 @@ class TestGetCustomProperties(cases.GraphQLTestCase):
                 'fieldId': self.customfields[2].pk,
                 'fieldLabel': self.customfields[2].field_name,
                 'fieldValue': 'Design',
-
+            },
+            {
+                'fieldId': self.customfields[3].pk,
+                'fieldLabel': self.customfields[3].field_name,
+                'fieldValue': {
+                    'id': helpers.to_global_id('GroupType', self.group.id),
+                    'name': self.group.name,
+                    'pk': self.group.pk,
+                    'type': 'Group',
+                },
             },
         ])
 

--- a/www/src/app/Datastores/CustomProperties/Displays/GroupDisplay.js
+++ b/www/src/app/Datastores/CustomProperties/Displays/GroupDisplay.js
@@ -1,0 +1,14 @@
+import React, { Fragment } from "react"
+import GroupProfilePopover from "app/Groups/GroupProfilePopover"
+
+const GroupDisplay = ({ value }) => (
+    <Fragment>
+        {value && value.hasOwnProperty("name") && (
+            <GroupProfilePopover groupId={value.id}>
+                {value.name}
+            </GroupProfilePopover>
+        )}
+    </Fragment>
+)
+
+export default GroupDisplay

--- a/www/src/app/Datastores/CustomProperties/Displays/index.js
+++ b/www/src/app/Datastores/CustomProperties/Displays/index.js
@@ -2,6 +2,7 @@ import React from "react"
 import EnumDisplay from "./EnumDisplay"
 import TextDisplay from "./TextDisplay"
 import UserDisplay from "./UserDisplay"
+import GroupDisplay from "./GroupDisplay"
 
 export const renderDisplay = (customField, fieldValue) => {
   if (!customField || !fieldValue) return null
@@ -10,6 +11,7 @@ export const renderDisplay = (customField, fieldValue) => {
     TEXT: TextDisplay,
     ENUM: EnumDisplay,
     USER: UserDisplay,
+    GROUP: GroupDisplay,
   }
 
   const Component = switchBoard[customField.fieldType]

--- a/www/src/app/Datastores/CustomProperties/Inputs/GroupInput.js
+++ b/www/src/app/Datastores/CustomProperties/Inputs/GroupInput.js
@@ -1,0 +1,34 @@
+import React from "react"
+import { Select } from "antd"
+import { map, orderBy } from "lodash"
+
+const GroupInput = ({ form, initialValue, field: { pk }, choices }) => (
+  <>
+    {form.getFieldDecorator(pk, {
+      initialValue:
+        initialValue && initialValue.hasOwnProperty("pk")
+          ? initialValue.pk
+          : null,
+    })(
+      <Select data-test={`CustomProperties.Input(${pk})`}>
+        {map(orderBy(choices, 'name'), ({ pk, name }) => (
+          <Select.Option key={pk} value={pk}>
+            {name}
+          </Select.Option>
+        ))}
+        <Select.Option key={""} value={""}>
+          (reset this property)
+        </Select.Option>
+      </Select>
+    )}
+  </>
+)
+
+GroupInput.defaultProps = {
+  choices: [],
+  initialValue: {
+    pk: null,
+  },
+}
+
+export default GroupInput

--- a/www/src/app/Datastores/CustomProperties/Inputs/index.js
+++ b/www/src/app/Datastores/CustomProperties/Inputs/index.js
@@ -3,6 +3,7 @@ import React from "react"
 import EnumInput from "./EnumInput"
 import TextInput from "./TextInput"
 import UserInput from "./UserInput"
+import GroupInput from "./GroupInput"
 
 export const getInputComponent = (customField) => {
   if (!customField) return null
@@ -11,6 +12,7 @@ export const getInputComponent = (customField) => {
     TEXT: TextInput,
     ENUM: EnumInput,
     USER: UserInput,
+    GROUP: GroupInput,
   }
 
   return switchBoard[customField.fieldType]

--- a/www/src/app/Datastores/CustomProperties/UpdateCustomProperties.js
+++ b/www/src/app/Datastores/CustomProperties/UpdateCustomProperties.js
@@ -1,14 +1,15 @@
 import React, { Component } from "react"
 import { graphql, compose } from "react-apollo"
 import { Card, Form, Empty, Tooltip } from "antd"
-import { map, keyBy } from "lodash"
+import { map, filter, keyBy } from "lodash"
 import { withWriteAccess } from "hoc/withPermissionsRequired"
 import GetCustomProperties from "graphql/queries/GetCustomProperties"
 import UpdateCustomPropertiesMutation from "graphql/mutations/UpdateCustomProperties"
 import withGraphQLMutation from "hoc/withGraphQLMutation"
-import withLoader from "hoc/withLoader"
+import { withLargeLoader } from "hoc/withLoader"
 import withGetCustomFields from "graphql/withGetCustomFields"
 import withGetCustomPropertyUsers from "graphql/withGetCustomPropertyUsers"
+import withGetWorkspaceGroups from "graphql/withGetWorkspaceGroups"
 import CustomPropertiesFooter from "./CustomPropertiesFooter"
 import CustomPropertiesHeader from "./CustomPropertiesHeader"
 import { renderDisplay } from "./Displays"
@@ -84,12 +85,20 @@ class UpdateCustomProperties extends Component {
     )
   }
 
+  isEmpty() {
+    return filter(
+      this.props.customProperties,
+      ({ fieldValue }) => fieldValue !== null && fieldValue !== ""
+    ).length === 0
+  }
+
   render() {
     const { isEditing } = this.state
     const {
       customFields,
       customProperties,
       form,
+      workspaceGroups: groups,
       hasPermission,
       submitting,
       users,
@@ -106,14 +115,12 @@ class UpdateCustomProperties extends Component {
         }
       >
         <Form
-          className="custom-fields-form"
+          className={`custom-fields-form ${isEditing && 'editing'}`}
           labelCol={{ span: 7 }}
           wrapperCol={{ span: 17 }}
           onSubmit={this.handleSubmit}
         >
-          {customProperties.length === 0 ? (
-            <Empty />
-          ) : (
+          {this.isEmpty() && !isEditing ? ( <Empty description={null} /> ) : (
             <>
               {map(customProperties, ({ fieldId, fieldLabel, fieldValue }) => {
                 const field = fields[fieldId]
@@ -127,6 +134,8 @@ class UpdateCustomProperties extends Component {
                 }
                 if (fields[fieldId].fieldType === "USER") {
                   inputProps.choices = users
+                } else if (fields[fieldId].fieldType === "GROUP") {
+                  inputProps.choices = groups
                 } else if (fields[fieldId].fieldType === "ENUM") {
                   inputProps.choices = field.validators.choices
                 }
@@ -159,25 +168,17 @@ class UpdateCustomProperties extends Component {
   }
 }
 
-const withLargeLoader = withLoader({
-  size: "large",
-  wrapperstyles: {
-    textAlign: "center",
-    marginTop: "40px",
-    marginBottom: "40px",
-  },
-})
-
 const withForm = Form.create()
 
 const enhance = compose(
-  withLargeLoader,
   withForm,
   withWriteAccess,
   withGetCustomFields,
   withGetCustomPropertyUsers,
+  withGetWorkspaceGroups,
   graphql(UpdateCustomPropertiesMutation),
-  withGraphQLMutation
+  withGraphQLMutation,
+  withLargeLoader,
 )
 
 export default enhance(UpdateCustomProperties)

--- a/www/src/app/WorkspaceSettings/CustomFields/CustomFieldFieldset.js
+++ b/www/src/app/WorkspaceSettings/CustomFields/CustomFieldFieldset.js
@@ -31,6 +31,7 @@ const fieldsetMapping = {
   ENUM: EnumTypeFieldset,
   TEXT: null,
   USER: null,
+  GROUP: null,
 }
 
 const CustomFieldFieldset = ({

--- a/www/src/graphql/queries/GetWorkspaceGroups.js
+++ b/www/src/graphql/queries/GetWorkspaceGroups.js
@@ -5,6 +5,7 @@ export default gql`
     workspaceGroups {
       edges {
         node {
+          pk
           id
           name
           description

--- a/www/src/pages/Datastores/_datastores.scss
+++ b/www/src/pages/Datastores/_datastores.scss
@@ -464,6 +464,11 @@
   display: table;
   clear: both;
 }
+.custom-fields-form.editing {
+  .custom-property .labelWrap {
+    line-height: 30px;
+  }
+}
 .custom-property {
   .labelWrap {
     text-align: right;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Feature

## Description

Extends custom fields to accept Group objects as a type. This is useful for labeling data assets with teams or other functional user groups.