### PR TITLE
feat: Redirect to intended URL after login

### DIFF
--- a/www/cypress/integration/authentication.spec.js
+++ b/www/cypress/integration/authentication.spec.js
@@ -220,4 +220,72 @@ describe("authentication.spec.js", () => {
       cy.title().should("eq", "Log In - Metamapper")
     })
   })
+
+  describe("automatic redirection", () => {
+
+    it("does not redirect to cross-origin domain", () => {
+      cy.visit("/login?next=https://www.google.com")
+
+      continueWithEmail(validUser.email)
+
+      cy.getByTestId("LoginForm.Password").type(validUser.password)
+      cy.contains("button", "Sign In").click()
+
+      cy.location("pathname").should("equal", `/${workspace.slug}/datastores`)
+    })
+
+    it("redirects to root when target is login page", () => {
+      cy.visit("/login?next=http%3A%2F%2Flocalhost%3A5050%2Flogin")
+
+      continueWithEmail(validUser.email)
+
+      cy.getByTestId("LoginForm.Password").type(validUser.password)
+      cy.contains("button", "Sign In").click()
+
+      cy.location("pathname").should("equal", `/${workspace.slug}/datastores`)
+    })
+
+    it("redirects to 404 when page is invalid", () => {
+      cy.visit(`/login?next=http%3A%2F%2Flocalhost%3A5050%2F${workspace.slug}%2Fdoes-not%2Fexist`)
+
+      continueWithEmail(validUser.email)
+
+      cy.getByTestId("LoginForm.Password").type(validUser.password)
+      cy.contains("button", "Sign In").click()
+
+      cy.location("pathname").should("equal", `/${workspace.slug}/does-not/exist`)
+      cy.contains("Sorry, the page you are looking for doesn't exist.").should("be.visible")
+      cy.contains("Go Back Home").click()
+      cy.location("pathname").should("equal", `/${workspace.slug}/datastores`)
+    })
+
+    it("redirects when added automatically", () => {
+      cy.visit(`/${workspace.slug}/settings/groups`)
+
+      cy.location("pathname").should("equal", "/login")
+      cy.location("search").should("equal", `?next=http%3A%2F%2Flocalhost%3A5050%2F${workspace.slug}%2Fsettings%2Fgroups`)
+
+
+      continueWithEmail(validUser.email)
+
+      cy.getByTestId("LoginForm.Password").type(validUser.password)
+      cy.contains("button", "Sign In").click()
+
+      cy.location("pathname").should("equal", `/${workspace.slug}/settings/groups`)
+    })
+
+    it("redirects when added manually", () => {
+      cy.visit(`/login?next=http%3A%2F%2Flocalhost%3A5050%2F${workspace.slug}%2Fsettings%2Fgroups`)
+
+      cy.location("pathname").should("equal", "/login")
+      cy.location("search").should("equal", `?next=http%3A%2F%2Flocalhost%3A5050%2F${workspace.slug}%2Fsettings%2Fgroups`)
+
+      continueWithEmail(validUser.email)
+
+      cy.getByTestId("LoginForm.Password").type(validUser.password)
+      cy.contains("button", "Sign In").click()
+
+      cy.location("pathname").should("equal", `/${workspace.slug}/settings/groups`)
+    })
+  })
 })

--- a/www/cypress/integration/sso.spec.js
+++ b/www/cypress/integration/sso.spec.js
@@ -276,6 +276,10 @@ describe("sso.spec.js", () => {
     })
   })
 
+  describe("automatic redirection", () => {
+
+  })
+
   describe("404", () => {
     it("when workspace does not exist", () => {
       cy.login(owner.email, owner.password, workspace.id)

--- a/www/src/app/Authentication/AuthForm.js
+++ b/www/src/app/Authentication/AuthForm.js
@@ -65,10 +65,13 @@ class AuthForm extends React.Component {
   }
 
   handleError = (e) => {
-    this.setState({
-      submitting: false,
-      ...this.props.onError(e)
-    })
+    let state = { submitting: false }
+
+    if (this.props.onError) {
+      state = { ...state, ...this.props.onError(e) }
+    }
+
+    this.setState(state)
   }
 
   render() {

--- a/www/src/hoc/withSessionRequired.js
+++ b/www/src/hoc/withSessionRequired.js
@@ -33,13 +33,20 @@ export default (
         match: { params },
       } = this.props
 
+      const authToken = localStorage.getItem(AUTH_TOKEN)
+
+      if (shouldRefreshUser || (authToken && !currentUser) || (!authToken && currentUser)) {
+        this.props.refreshUser()
+        return null;
+      }
+
       let { currentWorkspace } = this.props
       if (config) {
         currentWorkspace = config.getCurrentWorkspace()
       }
 
       // Force reload to capture current workspace if the URL doesn't match.
-      if (params.hasOwnProperty("workspaceSlug")) {
+      if (currentUser && params.hasOwnProperty("workspaceSlug")) {
         const workspace = find(myWorkspaces, { slug: params.workspaceSlug })
 
         if (!currentWorkspace && workspace) {
@@ -59,13 +66,6 @@ export default (
         }
       }
 
-      const authToken = localStorage.getItem(AUTH_TOKEN)
-
-      if (shouldRefreshUser || (authToken && !currentUser) || (!authToken && currentUser)) {
-        this.props.refreshUser()
-        return null;
-      }
-
       // If login screen, redirect to the dashboard.
       if (!isProtected && currentUser) {
         this.props.history.push("/")
@@ -74,7 +74,7 @@ export default (
       // If it is a restricted route and currentUser is
       // not authenticated, redirect to Login page.
       if (isProtected && !currentUser && pathname !== "/login") {
-        this.props.history.push("/login")
+        this.props.history.push(`/login?next=${encodeURIComponent(window.location.href)}`)
       } else if (
         isProtected &&
         !currentWorkspace &&

--- a/www/src/lib/utilities.js
+++ b/www/src/lib/utilities.js
@@ -103,15 +103,57 @@ export const setToken = (token) => {
   window.localStorage.setItem(AUTH_TOKEN, token)
 }
 
-export const setTokenAndGetRedirectUri = (token, unset = false) => {
-  const redirect_uri = window.localStorage.getItem(REDIRECT_URI)
-  const redirect_url = redirect_uri ? decodeURIComponent(redirect_uri) : "/"
-
+export const setTokenAndGetRedirectUri = (token, defaultPath) => {
   setToken(token)
+  return parseRedirectUri(getWithExpiry(REDIRECT_URI), defaultPath)
+}
 
-  if (unset) {
-    window.localStorage.removeItem(REDIRECT_URI)
+export const parseRedirectUri = (next, defaultPath = "/") => {
+  if (next) {
+    const { origin } = parseURL(next)
+
+    if (origin && origin === window.location.origin) {
+      return next
+    }
   }
 
-  return redirect_url
+  return defaultPath
+}
+
+export const parseURL = (string) => {
+  try {
+    return new URL(string);
+  } catch (_) {
+    return {};
+  }
+}
+
+export const setWithExpiry = (key, value, ttl) => {
+  const now = new Date()
+
+  // `item` is an object which contains the original value
+  // as well as the time when it's supposed to expire
+  const item = {
+    value: value,
+    expiry: now.getTime() + ttl,
+  }
+  localStorage.setItem(key, JSON.stringify(item))
+}
+
+export const getWithExpiry = (key) => {
+  const itemStr = localStorage.getItem(key)
+  // if the item doesn't exist, return null
+  if (!itemStr) {
+    return null
+  }
+  const item = JSON.parse(itemStr)
+  const now = new Date()
+  // compare the expiry time of the item with the current time
+  if (now.getTime() > item.expiry) {
+    // If the item is expired, delete the item from storage
+    // and return null
+    localStorage.removeItem(key)
+    return null
+  }
+  return item.value
 }

--- a/www/src/pages/Authentication/Login.js
+++ b/www/src/pages/Authentication/Login.js
@@ -3,7 +3,8 @@ import { Helmet } from "react-helmet"
 import { graphql } from "react-apollo"
 import { Col, Row } from "antd"
 import { Link } from "react-router-dom"
-import { setTokenAndGetRedirectUri } from "lib/utilities"
+import { setToken, parseRedirectUri } from "lib/utilities"
+import qs from "query-string"
 import AuthenticateUser from "graphql/mutations/AuthenticateUser"
 import AuthForm from "app/Authentication/AuthForm"
 import LoginForm from "app/Authentication/LoginForm"
@@ -28,8 +29,11 @@ class Login extends Component {
 
   handleSuccess = ({ data }) => {
     const { token } = data.tokenAuth
+    const { next } = qs.parse(this.props.location.search)
+
     if (token) {
-      this.props.history.push(setTokenAndGetRedirectUri(token))
+      setToken(token)
+      window.location.href = parseRedirectUri(next, "/")
     }
   }
 

--- a/www/src/pages/Authentication/LoginPrompt.js
+++ b/www/src/pages/Authentication/LoginPrompt.js
@@ -3,6 +3,7 @@ import { Col, Row } from "antd"
 import { graphql, compose } from "react-apollo"
 import { Helmet } from "react-helmet"
 import { withRouter } from "react-router-dom"
+import qs from "query-string"
 import CheckUserExists from "graphql/mutations/CheckUserExists"
 import TriggerSingleSignOn from "graphql/mutations/TriggerSingleSignOn"
 import AuthForm from "app/Authentication/AuthForm"
@@ -21,14 +22,29 @@ class LoginPrompt extends Component {
   }
 
   handleSuccess = ({ data }) => {
-    const { email, ok, isSSOForced, workspaceSlug } = data.userExistsCheck
+    const {
+      email,
+      isSSOForced,
+      ok,
+      workspaceSlug,
+    } = data.userExistsCheck
+
+    const { next } = qs.parse(this.props.location.search)
+
+    let nextParam = ''
+    if (next) {
+      nextParam = `&next=${encodeURIComponent(next)}`
+    }
 
     if (ok) {
-      // Redirect
       if (isSSOForced && workspaceSlug) {
-        this.props.history.push(`/login/sso/${workspaceSlug}`)
+        this.props.history.push(
+          `/login/sso/${workspaceSlug}?sso=1${nextParam}`
+        )
       } else {
-        this.props.history.push(`/login/email?email=${email}`)
+        this.props.history.push(
+          `/login/email?email=${email}${nextParam}`
+        )
       }
     } else {
       this.props.history.push(`/signup?email=${email}`)

--- a/www/src/pages/Authentication/LoginWithToken.js
+++ b/www/src/pages/Authentication/LoginWithToken.js
@@ -2,6 +2,7 @@ import React, { Component } from "react"
 import { compose, graphql } from "react-apollo"
 import { withRouter } from "react-router"
 import { Spin } from "antd"
+import { setTokenAndGetRedirectUri } from "lib/utilities"
 import { AUTH_TOKEN, WORKSPACE_TOKEN } from "lib/constants"
 import LoginWithSSOTokenMutation from "graphql/mutations/LoginWithSSOToken"
 import withGetWorkspaceBySlug from "graphql/withGetWorkspaceBySlug"
@@ -28,13 +29,11 @@ class LoginWithToken extends Component {
         },
       })
       .then(({ data: { loginWithSSOToken } }) => {
-        const { jwt } = loginWithSSOToken
+        const { jwt: token } = loginWithSSOToken
 
-        if (jwt) {
-          window.localStorage.setItem(AUTH_TOKEN, jwt)
+        if (token) {
+          window.location.href = setTokenAndGetRedirectUri(token, `/${workspaceSlug}`)
         }
-
-        window.location.href = `/${workspaceSlug}`
       })
   }
 

--- a/www/src/pages/Authentication/SingleSignOn.js
+++ b/www/src/pages/Authentication/SingleSignOn.js
@@ -2,6 +2,7 @@ import React, { Component } from "react"
 import { Helmet } from "react-helmet"
 import { graphql } from "react-apollo"
 import { Col, Row, message } from "antd"
+import qs from "query-string"
 import TriggerSingleSignOn from "graphql/mutations/TriggerSingleSignOn"
 import AuthForm from "app/Authentication/AuthForm"
 import SingleSignOnForm from "app/Authentication/SingleSignOnForm"
@@ -20,10 +21,19 @@ class SingleSignOn extends Component {
   }
 
   handleSuccess = ({ data }) => {
-    const { redirectUrl } = data.triggerSingleSignOn
+    const {
+      redirectUrl,
+    } = data.triggerSingleSignOn
+
+    const { next } = qs.parse(this.props.location.search)
+
+    let nextParam = ''
+    if (next) {
+      nextParam = `?next=${encodeURIComponent(next)}`
+    }
 
     if (redirectUrl) {
-      window.location.href = redirectUrl
+      window.location.href = `${redirectUrl}${nextParam}`
     } else {
       message.error(
         "Workspace does not exist or does not have Single Sign-On enabled."

--- a/www/src/pages/Authentication/SingleSignOnRedirect.js
+++ b/www/src/pages/Authentication/SingleSignOnRedirect.js
@@ -2,7 +2,10 @@ import React, { Component } from "react"
 import { compose, graphql } from "react-apollo"
 import { Spin, Icon } from "antd"
 import { withRouter } from "react-router-dom"
+import { REDIRECT_URI } from "lib/constants"
+import { setWithExpiry } from "lib/utilities"
 import TriggerSingleSignOn from "graphql/mutations/TriggerSingleSignOn"
+import qs from "query-string"
 
 class SingleSignOnRedirect extends Component {
   componentWillMount() {
@@ -11,6 +14,12 @@ class SingleSignOnRedirect extends Component {
         params: { workspaceSlug },
       },
     } = this.props
+
+    const { next } = qs.parse(this.props.location.search)
+
+    if (next) {
+      setWithExpiry(REDIRECT_URI, next, 15000)
+    }
 
     const httpRequest = this.props.mutate({
       variables: {
@@ -45,7 +54,7 @@ class SingleSignOnRedirect extends Component {
         <p>
           <Spin indicator={<Icon type="loading" />} size="large" />
         </p>
-        <p style={{ color: "#64b7fe" }}>
+        <p className="text-primary">
           Redirecting to your single sign-on provider.
         </p>
       </div>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [x] Feature

## Description

This PR adds a pretty nifty feature that redirects users to their desired page after hitting an authentication error. It works by appending a `next` URL parameter and then forwarding it through the login process until the user is authenticated, at which point we redirect to `next` if it is (a) a valid URL and (2) has the same origin as the current host.

## Related Issues and Documents

https://trello.com/c/KFpu5u7m