### PR TITLE
refactor: Remove max length from comment body

### DIFF
--- a/app/comments/serializers.py
+++ b/app/comments/serializers.py
@@ -34,7 +34,7 @@ def get_audit_kwargs(instance):
 class CommentSerializer(MetamapperSerializer, serializers.ModelSerializer):
     """Serializer for interacting with comments.
     """
-    html = serializers.CharField(required=True, min_length=1, max_length=2048)
+    html = serializers.CharField(required=True, min_length=1)
 
     content_object = fields.RelatedObjectField(
         allowed_models=Comment.commentable_types(),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [X] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Other

## Description

Pretty simple change – we currently cap the comment body at 2048 characters _after_ it's been converted into the HTML by the Trix Editor.

A few users have mentioned that this cuts them off before they are done writing whatever they want to write. Probably better to just remove it entirely.
