### PR TITLE
refactor: Include install_id for better usage reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV NODE_ENV $env
 WORKDIR /frontend
 COPY /www /frontend
 
-RUN npm ci --unsafe-perm
-RUN npm run build
+RUN npm ci --unsafe-perm --loglevel silent
+RUN npm run build --loglevel silent
 
 FROM python:3.7-stretch as base
 

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ help:
 setup: install-npm-pkgs build-assets build-docker initdb
 
 install-npm-pkgs:
-	@npm install --prefix www --quiet
+	@npm install --prefix www --loglevel silent
 
 build-assets:
-	@npm run build --prefix www
+	@npm run build --prefix www --loglevel silent
 
 build-docker:
 	@docker-compose -f docker-development.yml build --build-arg env=development

--- a/metamapper/__init__.py
+++ b/metamapper/__init__.py
@@ -1,6 +1,7 @@
 # flake8: noqa
 from __future__ import absolute_import
 from os import environ
+from hashlib import sha1
 
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
@@ -20,6 +21,13 @@ except ImportError:
 
     if raise_import_exception:
         raise
+
+
+def get_install_id():
+    # We take an anonymized hash of the Django secret so we can
+    # accurately report on the number of production installations of
+    # Metamapper for usage purposes.
+    return sha1(settings.SECRET_KEY.encode('utf-8')).hexdigest()
 
 
 def get_version(prefix='v'):

--- a/metamapper/tasks.py
+++ b/metamapper/tasks.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from rest_framework import status
 from requests.exceptions import ConnectionError
 
-from metamapper import get_version, is_docker
+from metamapper import get_version, get_install_id, is_docker
 from metamapper.celery import app
 
 from utils import logging
@@ -42,6 +42,7 @@ def send_beacon(self):
         payload = {
             "docker": is_docker(),
             "version": get_version(),
+            "install_id": get_install_id(),
             "workspace_id": str(workspace.id),
             "usage": {
                 "team": workspace.team_members.count(),

--- a/metamapper/tests/test_tasks.py
+++ b/metamapper/tests/test_tasks.py
@@ -26,6 +26,7 @@ class BeaconUsageTaskTests(cases.UserFixtureMixin, cases.TestCase):
         self.assertEqual(mock_http_request.call_count, len(workspaces))
 
     @mock.patch('requests.post')
+    @override_settings(SECRET_KEY='meowmeowmeow')
     def test_execution_content(self, mock_http_request):
         """It should provide the correct data.
         """
@@ -42,6 +43,7 @@ class BeaconUsageTaskTests(cases.UserFixtureMixin, cases.TestCase):
             json={
                 'docker': False,
                 'version': 'v%s' % __version__,
+                'install_id': '29eda88ef0cff1bf5ced0821a6ed82eab16721a2',
                 'workspace_id': str(self.workspace.pk),
                 'usage': {
                     'team': 5,

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -12952,6 +12952,11 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
+    "silent": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/silent/-/silent-0.1.2.tgz",
+      "integrity": "sha1-+dHq8bg2tZmKSCROfnr5tw3KzyU="
+    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -12952,11 +12952,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
-    "silent": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/silent/-/silent-0.1.2.tgz",
-      "integrity": "sha1-+dHq8bg2tZmKSCROfnr5tw3KzyU="
-    },
     "simple-swizzle": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -7128,17 +7128,17 @@
       }
     },
     "i18next-http-backend": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.0.17.tgz",
-      "integrity": "sha512-puuvW34DTeZcy4for3so0MqZHNFMOyURgnwWo8zkhurMPREZmn5l/4Bv0o3tXWOrZrWsn+WDCytE2yjNWec8zw==",
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-1.0.19.tgz",
+      "integrity": "sha512-ouxq5iospZw2j4gnngNzCqDUPdMhkNeV5ROm1rKWaWJWR/dBt+LMYnta/AAOX1LmopaCxgiYQXUcTSpimyYYWw==",
       "requires": {
-        "node-fetch": "2.6.0"
+        "node-fetch": "2.6.1"
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },

--- a/www/package.json
+++ b/www/package.json
@@ -35,7 +35,6 @@
     "react-scripts": "^3.4.3",
     "react-trix": "^0.6.0",
     "sass": "^1.26.10",
-    "silent": "^0.1.2",
     "store2": "^2.10.0"
   },
   "scripts": {

--- a/www/package.json
+++ b/www/package.json
@@ -35,6 +35,7 @@
     "react-scripts": "^3.4.3",
     "react-trix": "^0.6.0",
     "sass": "^1.26.10",
+    "silent": "^0.1.2",
     "store2": "^2.10.0"
   },
   "scripts": {

--- a/www/package.json
+++ b/www/package.json
@@ -17,7 +17,7 @@
     "graphql": "^14.5.8",
     "graphql-tag": "^2.10.1",
     "i18next": "^19.6.3",
-    "i18next-http-backend": "^1.0.17",
+    "i18next-http-backend": "^1.0.19",
     "interweave": "^12.2.0",
     "interweave-autolink": "^4.2.1",
     "js-yaml": "^3.14.0",


### PR DESCRIPTION
We take a `sha1` hash of the Django secret so we can deduplicate the beacon and discover how many active installations exist in the wild.