### PR TITLE
refactor: Make ES client configurable

### DIFF
--- a/app/omnisearch/backends/elastic_backend.py
+++ b/app/omnisearch/backends/elastic_backend.py
@@ -30,9 +30,7 @@ class ElasticBackend(base.BaseSearchBackend):
     def create_client(cls, *args, **kwargs):
         return Elasticsearch(
             [settings.ELASTIC_URL],
-            sniff_on_start=True,
-            sniff_on_connection_fail=True,
-            sniffer_timeout=60,
+            **settings.ELASTIC_CLIENT_CONFIG,
         )
 
     def __new__(cls, *args, **kwargs):

--- a/app/omnisearch/backends/elastic_backend.py
+++ b/app/omnisearch/backends/elastic_backend.py
@@ -29,8 +29,8 @@ class ElasticBackend(base.BaseSearchBackend):
     @classmethod
     def create_client(cls, *args, **kwargs):
         return Elasticsearch(
-            [settings.ELASTIC_URL],
-            **settings.ELASTIC_CLIENT_CONFIG,
+            settings.ELASTIC_URL.split(','),
+            **settings.ELASTIC_CLIENT_KWARGS,
         )
 
     def __new__(cls, *args, **kwargs):

--- a/metamapper/settings.py
+++ b/metamapper/settings.py
@@ -430,6 +430,13 @@ ELASTIC_URL = os.getenv(
     'http://elastic:9200',
 )
 
+# This can be overridden via the settings.py file in your fork.
+ELASTIC_CLIENT_KWARGS = {
+    'sniff_on_start': True,
+    'sniff_on_connection_fail': True,
+    'sniffer_timeout': 60,
+}
+
 #
 # Django Storages (required)
 # (https://django-storages.readthedocs.io/en/1.9.1/index.html)


### PR DESCRIPTION
Service providers like AWS require slightly different ES configurations. To be as flexible as possible, we should allow people to override a constant dict that is passed into the `Elasticsearch` client.

https://elasticsearch-py.readthedocs.io/en/1.x/#running-with-aws-elasticsearch-service